### PR TITLE
Multipage update on dates/times, participant guides link to Sac info guide, consultants now coaches, and other small changes.

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,7 +1,4 @@
-+++
-title = "About DataFest"
-+++
-
++++ title = "About DataFest" +++
 
 <style>
 .button {
@@ -17,44 +14,41 @@ title = "About DataFest"
 }
 </style>
 
+The [American Statistical Association's](https://ww2.amstat.org/education/datafest/) DataFest, founded at UCLA in 2011, is a 48-hour data analysis competition in which undergraduate students from various majors get to work in teams on large, complex, and real-world data. The data is kept secret until opening of the event on Friday evening and teams present their findings to a panel of judges on Sunday afternoon. Students explore, analyze, and visualize the data to discover insights. No prior knowledge of programming or data visualization is necessary!
 
+Previous years' data sets have included crime data from the LAPD, dating data from eHarmony, and even data from the Canadian Olympic Women's rugby team. This year's data set will be revealed at the opening of the event on Friday evening.
 
-The [American Statistical Association’s](https://ww2.amstat.org/education/datafest/) DataFest, founded at UCLA in 2011, is a 48-hour data analysis competition in which undergraduate students from various majors get to work in teams on large, complex, and real-world data. The data is kept secret until opening of the event on Friday evening and teams present their findings to a panel of judges on Sunday afternoon. Students explore, analyze, and visualize the data to discover insights. No prior knowledge of programming or data visualization is necessary! 
-
-Previous years’ data sets have included crime data from the LAPD, dating data from eHarmony, and even data from the Canadian Olympic Women's rugby team. This year’s data set will be revealed at the opening of the event on Friday evening. 
-
-At the conclusion of the competition, each team will have 5 minutes and 2 slides to make a presentation to a panel of judges. Judges will select teams to win prizes for areas such as “Best Insight”, "Best Visualization", and "Best use of External Data". 
+At the conclusion of the competition, each team will have 5 minutes and 2 slides to make a presentation to a panel of judges. Judges will select teams to win prizes for areas such as "Best Insight", "Best Visualization", and "Best use of External Data".
 
 The mission of DataFest is to expose undergraduate students to challenging questions with immediate real-world significance that can be addressed through data analysis. By working in teams, students with varying skill sets will combine their efforts and expand their collective data analysis horizons. Interaction among students, as well as with outside coaches will promote the sense that data analysis is a dynamic, engaging, and vibrant part of our society, as well as a realistic, practical, and fun career path.
 
-----
+------------------------------------------------------------------------
 
 <!----
 # Who is at ASA DataFest @ Sacramento State 2024? 
 
 - 30 participants
-- 8 consultants
+- 8 coaches
 - 4 organizers
 - 3 judges
 ---->
 
-
 # Helpful Guides
-_Updated for 2024._
 
-<a href="/info_guide_chico"><button class="button">For Participants</button></a>
-<a href="/coach_judge_info"><button class="button">For Coaches & Judges</button></a>
+*Updating for 2025 in progress\...*
 
----
+<a href="/info_guide_sac"><button class="button">For Participants</button></a> <a href="/coach_judge_info"><button class="button">For Coaches & Judges</button></a>
 
-# DataFest in the news: 
+------------------------------------------------------------------------
 
-If you would like to write about or cover DataFest at Chico State in any way, please don't hesitate to contact us.
+# DataFest in the news:
 
-* [DataFest Competition Engages Students Across Disciplines](https://www.csuchico.edu/cob/news/datafest.shtml) - Chico State News, June 6, 2019
-* [DataFest Shows Spike in Growth, Provides Immersive Experience](http://magazine.amstat.org/blog/2017/09/01/datafest-2/) - AMSTAT News, September 1, 2017
-* [DataFest draws hundreds to solve stats challenges](http://www.dukechronicle.com/article/2015/03/datafest-draws-hundreds-solve-stats-challenges) - The Chronicle - March 23, 2015
-* [Big Data Goes to College](http://magazine.amstat.org/blog/2014/06/01/datafest/) - AMSTAT News - June 1, 2014
-* [The Students Most Likely to Take Our Jobs](http://fivethirtyeight.com/datalab/the-students-most-likely-to-take-our-jobs/) - FiveThirtyEight.com - May 2, 2014
+If you would like to write about or cover NorCal ASA DataFest in any way, please don't hesitate to contact us.
 
-
+<!-- Broken Link
+-   [DataFest Competition Engages Students Across Disciplines](https://www.csuchico.edu/cob/news/datafest.shtml) - Chico State News, June 6, 2019
+-->
+-   [DataFest Shows Spike in Growth, Provides Immersive Experience](http://magazine.amstat.org/blog/2017/09/01/datafest-2/) - AMSTAT News, September 1, 2017
+-   [DataFest draws hundreds to solve stats challenges](http://www.dukechronicle.com/article/2015/03/datafest-draws-hundreds-solve-stats-challenges) - The Chronicle - March 23, 2015
+-   [Big Data Goes to College](http://magazine.amstat.org/blog/2014/06/01/datafest/) - AMSTAT News - June 1, 2014
+-   [The Students Most Likely to Take Our Jobs](http://fivethirtyeight.com/datalab/the-students-most-likely-to-take-our-jobs/) - FiveThirtyEight.com - May 2, 2014

--- a/content/faq.md
+++ b/content/faq.md
@@ -1,14 +1,12 @@
-+++
-title = "Info"
-+++
++++ title = "Info" +++
 
-DataFest is a nationally-coordinated undergraduate competition in which teams of up to 5 students work over a weekend to extract insight from a rich and complex data set. Previous years’ data sets have included crime data from the LAPD, dating data from eHarmony, and energy use data from GridPoint. This year’s data set will be revealed at the opening of the event on Friday evening. 
+DataFest is a nationally-coordinated undergraduate competition in which teams of up to 5 students work over a weekend to extract insight from a rich and complex data set. Previous years' data sets have included crime data from the LAPD, dating data from eHarmony, and energy use data from GridPoint. This year's data set will be revealed at the opening of the event on Friday evening.
 
-At the conclusion of the competition, each team will have 5 minutes and 2 slides to make a presentation to a panel of judges. Judges will select teams to win prizes for areas such as “Best Insight”, "Best Visualization", "Best use of external data", and one judges's personal favorite "Best Garbage Detection". 
+At the conclusion of the competition, each team will have 5 minutes and 2 slides to make a presentation to a panel of judges. Judges will select teams to win prizes for areas such as "Best Insight", "Best Visualization", "Best use of external data", and one judges's personal favorite "Best Garbage Detection".
 
-The mission of DataFest is to expose undergraduate students to challenging questions with immediate real-world significance that can be addressed through data analysis. By working in teams, students with varying skill sets will combine their efforts and expand their collective data analysis horizons. Interaction among students, as well as with outside consultants will promote the sense that data analysis is a dynamic, engaging, and vibrant part of our society, as well as a realistic, practical, and fun career path.
+The mission of DataFest is to expose undergraduate students to challenging questions with immediate real-world significance that can be addressed through data analysis. By working in teams, students with varying skill sets will combine their efforts and expand their collective data analysis horizons. Interaction among students, as well as with outside coaches will promote the sense that data analysis is a dynamic, engaging, and vibrant part of our society, as well as a realistic, practical, and fun career path.
 
----
+------------------------------------------------------------------------
 
 ## FAQ
 
@@ -22,27 +20,27 @@ All undergraduate students from any school in the Northern California Region are
 
 *What about MS students?*
 
-We would love to have Masters students get involved as consultants during the event.
+We would love to have Masters students get involved as coaches during the event.
 
 *How large are the teams?*
 
-Teams can be made up of 2-5 students. [[Register your team here]](https://forms.gle/RAf3fP3SaSRJyJ6Y6)
+Teams can be made up of 2-5 students. [\[Register your team here\]](/register.md)
 
 *Do I have to compete in a team?*
 
-Yes, but if you don't have a pre-formed team you can [[leave us your info here]](https://docs.google.com/spreadsheets/d/1krf5bhp_LxuOaWDG7KQ4U6DbQ_U-3O0RM1xxxjutN9Y/edit#gid=0) and we'll try to match you with others in the same boat. We will also be holding at least one team formation event prior to DataFest. 
+Yes, but if you don't have a pre-formed team you can [\[leave us your info here\]](https://docs.google.com/spreadsheets/d/1krf5bhp_LxuOaWDG7KQ4U6DbQ_U-3O0RM1xxxjutN9Y/edit#gid=0) and we'll try to match you with others in the same boat. We will also be holding at least one team formation event prior to DataFest.
 
 *What do I need to bring?*
 
-* A laptop with tools for data analysis (there is no limitation on which software you use) - with power charger
-* A water bottle
-* Enthusiasm for data! 
+-   A laptop with tools for data analysis (there is no limitation on which software you use) - with power charger
+-   A water bottle
+-   Enthusiasm for data!
 
 *What are the rules of the competition?*
 
-* Teams must consist of 2-5 students. 
-* Team members can come and go as they please but all work has to be done on-site. A steady supply of food, beverages, and snacks make it more inviting to stay.  
-* It's a competition, but a friendly one, so collaboration between teams is not only allowed but highly encouraged. Official ASA DataFest consultants (grad students, faculty, data professionals, etc.) will also be around throughout the weekend to help with any questions you might have. However you can't have outside help.   
+-   Teams must consist of 2-5 students.
+-   Team members can come and go as they please but all work has to be done on-site. A steady supply of food, beverages, and snacks make it more inviting to stay.  
+-   It's a competition, but a friendly one, so collaboration between teams is not only allowed but highly encouraged. Official ASA DataFest coaches (grad students, faculty, data professionals, etc.) will also be around throughout the weekend to help with any questions you might have. However you can't have outside help.
 
 *Do we have to stay the entire time?*
 
@@ -52,32 +50,32 @@ No. You may come and go as you please. However, you are not allowed to work on t
 
 Fame, glory, prizes or some combination thereof... And you get a t-shirt!
 
----
+------------------------------------------------------------------------
 
 ## Code of Conduct
 
 NorCal ASA DataFest<small><sup>TM</sup></small> is committed to providing a welcoming and harassment-free experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of event participants in any form. Sexual language and imagery is not appropriate for any event venue, including talks, workshops, social activities, social media, and other online media. ASA DataFest<small><sup>TM</sup></small> participants violating these rules may be sanctioned or expelled from the event at the discretion of the conference organizers.
 
-This code of conduct applies to all participants, including organizers, mentors / VIP consultants, judges, and helpers and applies to all modes of interaction, both in-person and online, on ASA DataFest<small><sup>TM</sup></small> Community, and event specific Slack channels, and social media.
+This code of conduct applies to all participants, including organizers, mentors / VIP coaches, judges, and helpers and applies to all modes of interaction, both in-person and online, on ASA DataFest<small><sup>TM</sup></small> Community, and event specific Slack channels, and social media.
 
 ASA participants agree to:
 
-- Be considerate in speech and actions, and actively seek to acknowledge and respect the boundaries of fellow attendees.
-- Refrain from demeaning, discriminatory, or harassing behavior and speech. Harassment includes, but is not limited to: deliberate intimidation; stalking; unwanted photography or recording; sustained or willful disruption of talks or other events; inappropriate physical contact; use of sexual or discriminatory imagery, comments, or jokes; and unwelcome sexual attention. If you feel that someone has harassed you or otherwise treated you inappropriately, please alert any organizers in person.
-- Take care of each other. Alert a member of the organizers if you notice a dangerous situation, someone in distress, or violations of this code of conduct, even if they seem inconsequential.
+-   Be considerate in speech and actions, and actively seek to acknowledge and respect the boundaries of fellow attendees.
+-   Refrain from demeaning, discriminatory, or harassing behavior and speech. Harassment includes, but is not limited to: deliberate intimidation; stalking; unwanted photography or recording; sustained or willful disruption of talks or other events; inappropriate physical contact; use of sexual or discriminatory imagery, comments, or jokes; and unwelcome sexual attention. If you feel that someone has harassed you or otherwise treated you inappropriately, please alert any organizers in person.
+-   Take care of each other. Alert a member of the organizers if you notice a dangerous situation, someone in distress, or violations of this code of conduct, even if they seem inconsequential.
 
 For more on the code of conduct, please see the [ASA Meeting Code of Conduct](https://www.amstat.org/ASA/Meetings/Meeting-Conduct-Policy.aspx).
 
 ### Need Help?
 
-Please speak with an event coordinator on site, email Robin Donatello at rdonatello@csuchico.edu, or send a message via the DataFest Slack channel (see the schedule of events for channel details.)
+Please speak with an event coordinator on site, email Robin Donatello at [rdonatello\@csuchico.edu](mailto:rdonatello@csuchico.edu), or send a message via the DataFest Slack channel (see the schedule of events for channel details.)
 
 If any attendee engages in harassing behavior, the event organizers may take any lawful action we deem appropriate, including but not limited to warning the offender or asking the offender to leave the conference. (If you feel you have been unfairly accused of violating this code of conduct, you should contact the organizers with a concise description of your grievance.)
 
 We welcome your feedback on this and every other aspect of ASA DataFest<small><sup>TM</sup></small> events, and we thank you for working with us to make it a safe, enjoyable, and friendly experience for everyone who participates.
 
-_The text above has been only slightly modified from Duke's DataFest website: https://www2.stat.duke.edu/datafest/coc/. Parts of above text is licensed CC BY-SA 4.0. Credit to rOpenSci and SRCCON. Also inspired by the Ada Initiative's "how to design a code of conduct for your community"._
+*The text above has been only slightly modified from Duke's DataFest website: <https://www2.stat.duke.edu/datafest/coc/>. Parts of above text is licensed CC BY-SA 4.0. Credit to rOpenSci and SRCCON. Also inspired by the Ada Initiative's "how to design a code of conduct for your community".*
 
----
+------------------------------------------------------------------------
 
 > In case you haven't found the answer for your question please feel free to contact us. We will be happy to help you.

--- a/content/info_guide_sac.Rmd
+++ b/content/info_guide_sac.Rmd
@@ -4,95 +4,140 @@ subtitle: https://norcaldatafest.netlify.com/
 output:
   html_document: default
   pdf_document: default
+editor_options: 
+  markdown: 
+    wrap: 72
 ---
 
+**Note: This document may be updated as the event approaches; any major
+updates will be clearly marked.**
 
-**Note: This document may be updated as the event approaches; any major updates will be clearly marked.**
-
-This is a long document, please take a moment to read over it carefully. 
+This is a long document, please take a moment to read over it carefully.
 
 <!-- **Presentation upload link for Sunday:** INSERT PRESENTATION UPLOAD LINK (See [presentations](#presentations) for details.) -->
 
-
-Sac State's Data Science club
-- Their discord will be the official event discord on that weekend
-https://discord.gg/UmCx7bWXGS 
-
+Sac State's Data Science club - Their discord will be the official event
+discord on that weekend <https://discord.gg/UmCx7bWXGS>
 
 # Location
 
-The event will be held in Eureka Hall on the Sacramento State campus. [Here is a link to an interactive map showing the event location and recommended parking.](https://www.google.com/maps/d/u/0/edit?mid=1T37DrPBRhMhvMuvecZpQqAjh7Ilq63c&usp=sharing) 
+The event will be held in Eureka Hall on the Sacramento State campus.
+[Here is a link to an interactive map showing the event location and
+recommended
+parking.](https://www.google.com/maps/d/u/0/edit?mid=1T37DrPBRhMhvMuvecZpQqAjh7Ilq63c&usp=sharing)
 
 ### Transportation & Parking
 
-* Parking Structure I provides the easiest access to Eureka Hall. [Click here for a map.](https://www.google.com/maps/d/u/0/edit?mid=1T37DrPBRhMhvMuvecZpQqAjh7Ilq63c&usp=sharing) 
-* Day parking is available for a small fee using the [PayByPhone app](https://www.paybyphone.com/drivers/how-it-works#step2). All student parking spaces double as day-use spaces for visitors.
+-   Parking Structure I provides the easiest access to Eureka Hall.
+    [Click here for a
+    map.](https://www.google.com/maps/d/u/0/edit?mid=1T37DrPBRhMhvMuvecZpQqAjh7Ilq63c&usp=sharing)
+-   Day parking is available for a small fee using the [PayByPhone
+    app](https://www.paybyphone.com/drivers/how-it-works#step2). All
+    student parking spaces double as day-use spaces for visitors.
 
 ### Lodging
 
-Hotels listed for less than approximately $100 per night are starred (\*).
+Hotels listed for less than approximately \$100 per night are starred
+(\*).
 
 #### Hotels within 1 mile of Sacramento State
 
-[Motel 6 Sacramento, CA - Central*](https://www.motel6.com/en/home/motels.9187.html)
-[Rodeway Inn Sacramento Central - University Area*](https://www.choicehotels.com/california/sacramento/rodeway-inn-hotels/cah72)
-[Hampton Inn & Suites Sacramento at CSUS](https://www.hilton.com/en/book/reservation/rooms/?ctyhocn=SACSUHX)
-[Comfort Inn & Suites Sacramento - University Area](https://www.choicehotels.com/california/sacramento/comfort-inn-hotels/ca644)
-
+-   [Motel 6 Sacramento, CA
+    Central\*](https://www.motel6.com/en/home/motels.9187.html)
+-   [Rodeway Inn Sacramento Central - University
+    Area\*](https://www.choicehotels.com/california/sacramento/rodeway-inn-hotels/cah72)
+-   [Hampton Inn & Suites Sacramento at
+    CSUS](https://www.hilton.com/en/book/reservation/rooms/?ctyhocn=SACSUHX)
+-   [Comfort Inn & Suites Sacramento - University
+    Area](https://www.choicehotels.com/california/sacramento/comfort-inn-hotels/ca644)
 
 ## Food & Caffeine
-Our goal is to keep you fed & caffeinated all weekend long. Check the Schedule for mealtimes. 
+
+Our goal is to keep you fed & caffeinated all weekend long. Check the
+Schedule for mealtimes.
 
 ## Security & Access
 
 # Social Media
 
-Did you know that, this year, DataFest will be held at [over 70 universities around the world](https://ww2.amstat.org/education/datafest/participants.cfm)? DataFest takes place during a six-week window in the Spring, and different universities hold their event at different times.
+Did you know that, this year, DataFest will be held at [over 70
+universities around the
+world](https://ww2.amstat.org/education/datafest/participants.cfm)?
+DataFest takes place during a six-week window in the Spring, and
+different universities hold their event at different times.
 
-An essential ingredient of Datafest is that the data be a surprise. There are several reasons for this. One is that it ensures that all teams start on an equal footing. Another is that, even if you research the organization that donated the data, you might still be totally unprepared for the context of the data (and maybe less prepared than had you known nothing!) Finally, it is simply more fun.
+An essential ingredient of Datafest is that the data be a surprise.
+There are several reasons for this. One is that it ensures that all
+teams start on an equal footing. Another is that, even if you research
+the organization that donated the data, you might still be totally
+unprepared for the context of the data (and maybe less prepared than had
+you known nothing!) Finally, it is simply more fun.
 
-You are encouraged to share your excitement on social media and thank our sponsors. The official Twitter hashtag is #ASAdatafest23. However...
+You are encouraged to share your excitement on social media and thank
+our sponsors. The official Twitter hashtag is #ASAdatafest25. However...
 
-PLEASE KEEP THE SECRET UNTIL April 29th!. Teams that leak the name or any information about the identify of the data donor will be disqualified!
+PLEASE KEEP THE SECRET UNTIL May 4th!. Teams that leak the name or any
+information about the identify of the data donor will be disqualified!
 
-Please do not post pictures that reveal any charts/graphs/tables/summaries/models that might reveal the data donor.
+Please do not post pictures that reveal any
+charts/graphs/tables/summaries/models that might reveal the data donor.
 
 # Presentations, judging, and awards
 
 ## Presentations
 
-Each team will have 4 minutes + 1 minute Q&A to present their findings to the judges. That’s exactly 4 minutes, not 4 minutes and a few additional seconds. Each team will be allowed at most two slides. Two! So at some point Saturday night or Sunday morning, you might want to set aside time to think about what you want the judges to know. The 4 minute presentation and 1 minute Q&A time limits will be strictly enforced. All team members must be present for the presentation, but not all team members need to actually speak (given the time limitation).
+Each team will have 4 minutes + 1 minute Q&A to present their findings
+to the judges. That’s exactly 4 minutes, not 4 minutes and a few
+additional seconds. Each team will be allowed at most two slides. Two!
+So at some point Saturday night or Sunday morning, you might want to set
+aside time to think about what you want the judges to know. The 4 minute
+presentation and 1 minute Q&A time limits will be strictly enforced. All
+team members must be present for the presentation, but not all team
+members need to actually speak (given the time limitation).
 
 **Optional**
 
-Along with your presentation you are also allowed to turn in a one-page write-up of your project. You can think about this as the text of your presentation. The judges can refer to these during deliberation. You will upload these documents along with your presentation. Only 1 page will be printed. 
+Along with your presentation you are also allowed to turn in a one-page
+write-up of your project. You can think about this as the text of your
+presentation. The judges can refer to these during deliberation. You
+will upload these documents along with your presentation. Only 1 page
+will be printed.
 
 #### Submitting your presentation
 
-At 1pm on Sunday all work must stop and you must upload your presentation and your optional write up to the submission website linked at the top of this page (available starting Sunday AM). If you are having technical difficulty, you can ask a consultant for help. Consultants will be around to help.
+At 1pm on Sunday all work must stop and you must upload your
+presentation and your optional write up to the submission website linked
+at the top of this page (available starting Sunday AM). If you are
+having technical difficulty, you can ask a coach for help. Coaches will
+be around to help.
 
-Teams who fail to upload their presentations and write-ups by 1:0pm on Sunday will not be eligible to have their presentations judged.
+Teams who fail to upload their presentations and write-ups by 1:00pm on
+Sunday will not be eligible to have their presentations judged.
 
 #### File naming
 
 The files you’re submitting must be named in the following manner:
 
-- [Team Name] - Presentation
-- [Team Name] - Writeup
+-   [Team Name] - Presentation
+-   [Team Name] - Writeup
 
 #### Allowed file formats
 
-- We very strongly recommend using PDF, Keynote, or PowerPoint.
-- If using a web-based tool like GoogleDocs or Prezi, please export to PDF and upload the PDF as your submission.
+-   We very strongly recommend using PDF, Keynote, or PowerPoint.
+-   If using a web-based tool like GoogleDocs or Prezi, please export to
+    PDF and upload the PDF as your submission.
 
-Note that you will not have time to log on/off to your account before your presentation. We don’t want to restrict your creativity but it is your responsibility to make sure that your presentation works seamlessly before the judging session begins.
+Note that you will not have time to log on/off to your account before
+your presentation. We don’t want to restrict your creativity but it is
+your responsibility to make sure that your presentation works seamlessly
+before the judging session begins.
 
 ## Judging
 
-The Judges will convene in a side room to deliberate and rank their nominations. 
-Three of these will be selected for the award categories listed below. 
-The judges also have the option to name a fourth winner as Judges' Pick.
-
+The Judges will convene in a side room to deliberate and rank their
+nominations. Three of these will be selected for the award categories
+listed below. The judges also have the option to name a fourth winner as
+Judges' Pick.
 
 All are welcomed to the presentations and award ceremony.
 
@@ -100,51 +145,89 @@ All are welcomed to the presentations and award ceremony.
 
 Awards will be given in three categories:
 
-- Best Insight
-- Best Use of Outside Data
-- Best Visualization
+-   Best Insight
+-   Best Use of Outside Data
+-   Best Visualization
 
 These are listed in no particular order.
 
 The judges also have the option to name a fourth winner as Judges' Pick.
 
-
-Winners will receive medals and books as well as one-year student memberships to the American Statistical Association. See http://www.amstat.org/membership/ for membership benefits.
+Winners will receive medals and books as well as one-year student
+memberships to the American Statistical Association. See
+<http://www.amstat.org/membership/> for membership benefits.
 
 #### Raffle prizes
 
-* Throughout the event we will be giving out raffle prizes. Announcements for these will be shared on social media or through Discord. Follow these channels to get a chance to win one of these sweet prizes! 
-* Winning will also require that you are on premises at the time a prize is announced.
+-   Throughout the event we will be giving out raffle prizes.
+    Announcements for these will be shared on social media or through
+    Discord. Follow these channels to get a chance to win one of these
+    sweet prizes!
+-   Winning will also require that you are on premises at the time a
+    prize is announced.
 
-##  Recruiting
+## Recruiting
 
-DataFest is a great recruiting opportunity for many employers, and surely they won’t miss it!
+DataFest is a great recruiting opportunity for many employers, and
+surely they won’t miss it!
 
-Many of our sponsors are attending the event so you can find out more about them. 
+Many of our sponsors are attending the event so you can find out more
+about them.
 
-Most of our consultants are coming from companies who are recruiting or at a minimum wanting to meet you, so chat with them, find out what they do, network.
+Most of our coaches are coming from companies who are recruiting or at a
+minimum wanting to meet you, so chat with them, find out what they do,
+network.
 
-We will collect resumes and share them with some of our sponsors. Participation in the resume book is optional, but highly recommended. You will receive information about this during the event.
-
+We will collect resumes and share them with some of our sponsors.
+Participation in the resume book is optional, but highly recommended.
+You will receive information about this during the event.
 
 # Rules
 
-- You can come and go as you please, but all work must be completed on premises.
+-   You can come and go as you please, but all work must be completed on
+    premises.
 
-- Do not use any space other than the designated classrooms, or work after 10pm Students found working in other areas or after 10pm will be disqualified from the competition.
+-   Do not use any space other than the designated classrooms, or work
+    after 10pm Students found working in other areas or after 10pm will
+    be disqualified from the competition.
 
-- You must follow the Code of Conduct. This can be found at https://norcaldatafest.netlify.com/faq/ and printed at the event. 
+-   You must follow the Code of Conduct. This can be found at
+    <https://norcaldatafest.netlify.com/faq/> and printed at the event.
 
-- Do not share the name of the data source publicly or on social media before April 29th. There are many other upcoming DataFests around the country and we want to make sure the dataset remains a surprise for them.
+-   Do not share the name of the data source publicly or on social media
+    before April 29th. There are many other upcoming DataFests around
+    the country and we want to make sure the dataset remains a surprise
+    for them.
 
-- Before your team gets the data all members must have signed Non-Disclosure agreement on file at the registration desk. You can freely share your results, presentations, findings, etc. as part of your digital portfolio, however you are not allowed to share the raw data with anyone outside of DataFest. At the end of DataFest, you must delete all data from thumb drives, hard drives, etc. The data are sensitive.
+-   Before your team gets the data all members must have signed
+    Non-Disclosure agreement on file at the registration desk. You can
+    freely share your results, presentations, findings, etc. as part of
+    your digital portfolio, however you are not allowed to share the raw
+    data with anyone outside of DataFest. At the end of DataFest, you
+    must delete all data from thumb drives, hard drives, etc. The data
+    are sensitive.
 
-- As much as possible during the event there will be a friendly consultants present. These are faculty, grad students, or other professionals from our community. Not all will have field specific knowledge on the data set. They all have different areas of expertise, so if you get stuck on something and one consultant isn’t able to help, ask someone else later. Feel free to ask anything. This is not an exam, but a collaborative competition. Do not expect the consultants to write code for you, or do data management, etc. They are there to help point you in the right direction, but you're responsible for getting there on your own.
+-   As much as possible during the event there will be a friendly
+    coaches present. These are faculty, grad students, or other
+    professionals from our community. Not all will have field specific
+    knowledge on the data set. They all have different areas of
+    expertise, so if you get stuck on something and one coach isn’t able
+    to help, ask someone else later. Feel free to ask anything. This is
+    not an exam, but a collaborative competition. Do not expect the
+    coaches to write code for you, or do data management, etc. They are
+    there to help point you in the right direction, but you're
+    responsible for getting there on your own.
 
-- PLEASE KEEP THE SECRET UNTIL MAY 4. Teams that leak the name or any information about the identify of the data donor will be disqualified! Please do not post pictures that reveal any charts/graphs/tables/summaries/models that might reveal the data donor.
+-   PLEASE KEEP THE SECRET UNTIL MAY 4. Teams that leak the name or any
+    information about the identify of the data donor will be
+    disqualified! Please do not post pictures that reveal any
+    charts/graphs/tables/summaries/models that might reveal the data
+    donor.
 
-- Please do not tweet, create a TikTok, hashtag, Facebook, snapchat, etc about the identify of the donor or the context of the data. This means you should refrain from any hints, explicit or implicit statements that might reveal the context of the data.
+-   Please do not tweet, create a TikTok, hashtag, Facebook, snapchat,
+    etc about the identify of the donor or the context of the data. This
+    means you should refrain from any hints, explicit or implicit
+    statements that might reveal the context of the data.
 
-- Be careful about github repositories. Make sure yours is invisible to the outside world.
-
-
+-   Be careful about github repositories. Make sure yours is invisible
+    to the outside world.

--- a/content/register.md
+++ b/content/register.md
@@ -1,7 +1,4 @@
-+++
-title= "Registration open until March 28, 2025"
-+++
-
++++ title= "Registration open until March 28, 2025" +++
 
 <style>
 .button {
@@ -19,48 +16,52 @@ title= "Registration open until March 28, 2025"
 
 ## <img src="../img/team.png"> [Participate as an Undergraduate Student Participant](https://forms.gle/WQLUZY2DMHZcs62Z8)
 
-<a href="/info_guide_chico"><button class="button">Participant guide</button></a>
+<a href="/info_guide_sac"><button class="button">Participant guide</button></a>
+
+#### Participants
+
+**Participants** will need to register as a team of 2-5 Northern California Region undergraduate students (Masters students can also participate as Coaches!). This is a free event with some food and beverages provided, though you will need to bring your own laptop equipped with preferred data analysis software. Participants may freely come and go, but all work must be done on site.
+
+Though this is indeed a competition, it is meant to be a friendly one! As such collaboration is highly encouraged. As well, ASA Datafest coaches (grad students, faculty, data professionals, et al.) will be available throughout to assist you.
 
 <br>
 
-## <img src="../img/consultation.png"> [Participate as an Event Helper](https://forms.gle/9mHyqLHFK67rEMYj6) 
+## <img src="../img/consultation.png"> [Participate as an Event Helper](https://forms.gle/9mHyqLHFK67rEMYj6)
 
-This could be as a **Coach**, a **Judge** or a general **event volunteer**. 
+This could be as a **Coach**, a **Judge** or a general **event volunteer**.
 
 <a href="/coach_judge_info"><button class="button">Volunteer guide</button></a>
 
-
 #### Coach
-**Coaches** walk around and talk with teams to see how they're doing. Help  them brainstorm ideas, refine ideas and most importantly help them come  back to reality in what is feasible in the 2 day period. Sometimes teams  have amazing ideas but either the data they need to answer their  question isn't collected/available, or the effort to complete the idea  is much larger than they realize. So trimming down ideas.
 
-Experience  with coding languages can be helpful, but not necessary. A general  ability to help them google the information is enough. For example, one  year the competition data involved certain substance use rates across a  geographic area. Some teams wanted to pull in census data to correlate  population demographic with substance use at the county level. That team  needed help figuring out where to get county level census information,  identifying what keys to join on and thinking about what level of  aggregation was reasonable to match on or display.
+**Coaches** walk around and talk with teams to see how they're doing. Help them brainstorm ideas, refine ideas and most importantly help them come back to reality in what is feasible in the 2 day period. Sometimes teams have amazing ideas but either the data they need to answer their question isn't collected/available, or the effort to complete the idea is much larger than they realize. So trimming down ideas.
+
+Experience with coding languages can be helpful, but not necessary. A general ability to help them google the information is enough. For example, one year the competition data involved certain substance use rates across a geographic area. Some teams wanted to pull in census data to correlate population demographic with substance use at the county level. That team needed help figuring out where to get county level census information, identifying what keys to join on and thinking about what level of aggregation was reasonable to match on or display.
 
 #### Judge
 
-Judges spend a few hours on Sunday listening to presentations, deliberating and awarding prizes. We strive to have a diverse panel of judges with at least one subject matter expert. 
+Judges spend a few hours on Sunday listening to presentations, deliberating and awarding prizes. We strive to have a diverse panel of judges with at least one subject matter expert.
 
 #### Event Volunteer
 
-This is a fully volunteer run event! We need people to do food pickups and meal setup, setup and breakdown, staff the registration desk to check students in, keep the snack table stocked, put up signage and answer questions as needed. 
+This is a fully volunteer run event! We need people to do food pickups and meal setup, setup and breakdown, staff the registration desk to check students in, keep the snack table stocked, put up signage and answer questions as needed.
 
-
----
+------------------------------------------------------------------------
 
 # Code of Conduct
 
-ASA DataFest<small><sup>TM</sup></small> at Chico State is committed to providing a welcoming and harassment-free experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of event participants in any form. Sexual language and imagery is not appropriate for any event venue, including talks, workshops, social activities, social media, and other online media. ASA DataFest<small><sup>TM</sup></small> participants violating these rules may be sanctioned or expelled from the event at the discretion of the conference organizers.
+Norcal ASA DataFest<small><sup>TM</sup></small> is committed to providing a welcoming and harassment-free experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of event participants in any form. Sexual language and imagery is not appropriate for any event venue, including talks, workshops, social activities, social media, and other online media. ASA DataFest<small><sup>TM</sup></small> participants violating these rules may be sanctioned or expelled from the event at the discretion of the conference organizers.
 
-This code of conduct applies to all participants, including organizers, mentors / VIP consultants, judges, and helpers and applies to all modes of interaction, both in-person and online, on ASA DataFest<small><sup>TM</sup></small> Community, and event specific Slack channels, and social media.
+This code of conduct applies to all participants, including organizers, mentors / VIP coaches, judges, and helpers and applies to all modes of interaction, both in-person and online, on ASA DataFest<small><sup>TM</sup></small> Community, and event specific Slack channels, and social media.
 
 ASA participants agree to:
 
-- Be considerate in speech and actions, and actively seek to acknowledge and respect the boundaries of fellow attendees.
-- Refrain from demeaning, discriminatory, or harassing behavior and speech. Harassment includes, but is not limited to: deliberate intimidation; stalking; unwanted photography or recording; sustained or willful disruption of talks or other events; inappropriate physical contact; use of sexual or discriminatory imagery, comments, or jokes; and unwelcome sexual attention. If you feel that someone has harassed you or otherwise treated you inappropriately, please alert any organizers in person.
-- Take care of each other. Alert a member of the organizers if you notice a dangerous situation, someone in distress, or violations of this code of conduct, even if they seem inconsequential.
+-   Be considerate in speech and actions, and actively seek to acknowledge and respect the boundaries of fellow attendees.
+-   Refrain from demeaning, discriminatory, or harassing behavior and speech. Harassment includes, but is not limited to: deliberate intimidation; stalking; unwanted photography or recording; sustained or willful disruption of talks or other events; inappropriate physical contact; use of sexual or discriminatory imagery, comments, or jokes; and unwelcome sexual attention. If you feel that someone has harassed you or otherwise treated you inappropriately, please alert any organizers in person.
+-   Take care of each other. Alert a member of the organizers if you notice a dangerous situation, someone in distress, or violations of this code of conduct, even if they seem inconsequential.
 
 For more on the code of conduct, please see the [ASA Meeting Code of Conduct](https://www.amstat.org/ASA/Meetings/Meeting-Conduct-Policy.aspx).
 
----
+------------------------------------------------------------------------
 
-<div>Icons made by <a href="https://www.freepik.com/" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" 			    title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" 			    title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div>
-
+<div>Icons made by <a href="https://www.freepik.com/" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/"              title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/"              title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div>

--- a/content/schedule.md
+++ b/content/schedule.md
@@ -1,6 +1,4 @@
-+++
-title= "Schedule of Events"
-+++
++++ title= "Schedule of Events" +++
 
 <html>
     <link rel="stylesheet" href="style.css" />
@@ -32,37 +30,49 @@ You are of course free to come and go as you please throughout the event, but he
     - Tue 4-2 2-4pm: DataFest Prep - Get the experience by playing with last year's DataFest data. 
 --->
 
-## Team Forming Event! 
+## Team Forming Event!
 
 Don't have a pre-formed team? Stay tuned for a team formation event one week prior to DataFest
 
+------------------------------------------------------------------------
 
-----
 # GO!
 
-## Friday, April 12th, 2024
-**Welcome!**  
- 
+## Friday, April 11th, 2024
+
+**Welcome!**
+
+-   5:00-10:00pm
+
+<!-- Come back to update specifics following this template:
 * 5pm - Registration sign in. 
 * 5:30pm - Kickoff presentation. Meet the data!
 * 6pm - Dinner
 * Room open until 12 midnight
+-->
 
+## Saturday, April 12th, 2024
 
-## Saturday, April 13th, 2024    
-**Carry on!**  
+**Carry on!**
 
+-   9:00am-10:00am
+
+<!-- Come back to update specifics following this template:
 * 8am - Breakfast    
 * 12pm - Lunch
 * 6:00pm - Dinner
 * Room open until 12 midnight 
+-->
 
-## Sunday, April 14th, 2024  
-**Wrap up!**  
- 
-* 8am - Breakfast    
-* 10am - Presentations due. 
-* 10:30am-12pm - Presentations and judges' deliberations. Special guest: Chico State President Perez   
+## Sunday, April 13th, 2024
+
+**Wrap up!**
+
+-   9:00am-12:00pm
+
+<!-- Come back to update specifics following this template:
+* 8am - Breakfast
+* 10am - Presentations due.
+* 10:30am-12pm - Presentations and judges' deliberations.
 * 12:30-1 - Award ceremony 
-
-
+-->

--- a/data/carousel/datafestlogo.yaml
+++ b/data/carousel/datafestlogo.yaml
@@ -1,4 +1,4 @@
 weight: 1
 title: "A celebration of data!"
-description: "<p><h3>April 12-14th, 2025 <br> @ CSU Sacramento!</p>"
+description: "<p><h3>April 11-13th, 2025 <br> @ CSU Sacramento!</p>"
 image: "img/carousel/datafest_logo_sac.png"


### PR DESCRIPTION
All pages: Updated dates, consultants to coaches, guides now link to info_guide_sac.Rmd. about.md: New statement on updatingfor 2025, Removed broken link from news section. faq.md: register link now points at register.md. info_guide_sac.Rmd: fixed list formatting on recommended hotel links. register.md: Added informational paragraph for participants, code of conduct now host agnostic. schedule.md: Replaced per day times with basic begins/ends times.